### PR TITLE
feat(hints): Add support for hints and grounding truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,20 +133,23 @@ console.log(transcript);
 
 ### Aligning AI Tokens to Human-Edited Text
 
-````typescript
+```typescript
 import { mapTokensToGroundTruth } from 'paragrafs';
 
 const rawSegment = {
-  start: 0,
-  end: 10,
-  text: 'The quick brown fox jumps right over the lazy dog.',
-  tokens: [ /* AI-generated word timestamps */ ]
+    start: 0,
+    end: 10,
+    text: 'The quick brown fox jumps right over the lazy dog.',
+    tokens: [
+        /* AI-generated word timestamps */
+    ],
 };
 
 const aligned = mapTokensToGroundTruth(rawSegment);
 console.log(aligned.tokens);
 // Each token now matches the ground-truth words exactly,
 // with missing words interpolated where needed.
+```
 
 ## API Reference
 
@@ -183,12 +186,10 @@ Combined utility that processes segments through all the necessary steps.
 #### `mapTokensToGroundTruth(segment: Segment): Segment`
 
 Synchronizes AI-generated word timestamps with the human-edited transcript (`segment.text`):
+
 - Uses a longest-common-subsequence (LCS) to find matching words and preserve their original timing.
 - Evenly interpolates timestamps for runs of missing words (only when two or more are missing).
 - Falls back to `estimateSegmentFromToken` if no matches are found.
-
-#### `groupMarkedTokensIntoSegments(markedTokens: MarkedToken[], maxSecondsPerSegment: number): MarkedSegment[]`
-  Groups marked tokens into logical segments based on maximum segment length.
 
 ### Types
 
@@ -210,7 +211,7 @@ type MarkedSegment = {
     end: number;
     tokens: MarkedToken[];
 };
-````
+```
 
 ### Utility Functions
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A lightweight TypeScript library designed to reconstruct paragraphs from OCRed i
 - **Customizable Parameters**: Configure minimum words per segment, max segment length, etc.
 - **Arabic Support**: Handles Arabic question marks and other non-Latin punctuation
 - **Transcript Formatting**: Converts raw token streams into readable text with appropriate line breaks
+- **Ground-Truth Token Mapping**: Aligns AI-generated word timestamps to human-edited transcript text using an LCS-based algorithm with intelligent interpolation
 
 ## Installation
 
@@ -42,6 +43,12 @@ or
 
 ```bash
 yarn add paragrafs
+```
+
+or
+
+```bash
+bun add paragrafs
 ```
 
 ## Usage
@@ -124,6 +131,23 @@ console.log(transcript);
 // 0:08: Jumps right over the
 ```
 
+### Aligning AI Tokens to Human-Edited Text
+
+````typescript
+import { mapTokensToGroundTruth } from 'paragrafs';
+
+const rawSegment = {
+  start: 0,
+  end: 10,
+  text: 'The quick brown fox jumps right over the lazy dog.',
+  tokens: [ /* AI-generated word timestamps */ ]
+};
+
+const aligned = mapTokensToGroundTruth(rawSegment);
+console.log(aligned.tokens);
+// Each token now matches the ground-truth words exactly,
+// with missing words interpolated where needed.
+
 ## API Reference
 
 ### Core Functions
@@ -156,6 +180,16 @@ Formats segments into a human-readable transcript with timestamps.
 
 Combined utility that processes segments through all the necessary steps.
 
+#### `mapTokensToGroundTruth(segment: Segment): Segment`
+
+Synchronizes AI-generated word timestamps with the human-edited transcript (`segment.text`):
+- Uses a longest-common-subsequence (LCS) to find matching words and preserve their original timing.
+- Evenly interpolates timestamps for runs of missing words (only when two or more are missing).
+- Falls back to `estimateSegmentFromToken` if no matches are found.
+
+#### `groupMarkedTokensIntoSegments(markedTokens: MarkedToken[], maxSecondsPerSegment: number): MarkedSegment[]`
+  Groups marked tokens into logical segments based on maximum segment length.
+
 ### Types
 
 ```typescript
@@ -176,7 +210,7 @@ type MarkedSegment = {
     end: number;
     tokens: MarkedToken[];
 };
-```
+````
 
 ### Utility Functions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub License](https://img.shields.io/github/license/ragaeeb/paragrafs)
 ![GitHub Release](https://img.shields.io/github/v/release/ragaeeb/paragrafs)
 [![codecov](https://codecov.io/gh/ragaeeb/paragrafs/graph/badge.svg?token=B3IRBVOS3H)](https://codecov.io/gh/ragaeeb/paragrafs)
-[![Size](https://deno.bundlejs.com/badge?q=paragrafs@1.0.0&badge=detailed)](https://bundlejs.com/?q=paragrafs%401.0.0)
+[![Size](https://deno.bundlejs.com/badge?q=paragrafs@1.2.0&badge=detailed)](https://bundlejs.com/?q=paragrafs%401.2.0)
 ![typescript](https://badgen.net/badge/icon/typescript?icon=typescript&label&color=blue)
 ![npm](https://img.shields.io/npm/dm/paragrafs)
 ![GitHub issues](https://img.shields.io/github/issues/ragaeeb/paragrafs)

--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
 
-    "@eslint/js": ["@eslint/js@9.25.0", "", {}, "sha512-iWhsUS8Wgxz9AXNfvfOPFSW4VfMXdVhp1hjkZVhXCrpgh/aLcc45rX6MPu+tIVUWDw0HfNwth7O28M1xDxNf9w=="],
+    "@eslint/js": ["@eslint/js@9.25.1", "", {}, "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
@@ -208,31 +208,31 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@types/bun": ["@types/bun@1.2.10", "", { "dependencies": { "bun-types": "1.2.10" } }, "sha512-eilv6WFM3M0c9ztJt7/g80BDusK98z/FrFwseZgT4bXCq2vPhXD4z8R3oddmAn+R/Nmz9vBn4kweJKmGTZj+lg=="],
+    "@types/bun": ["@types/bun@1.2.11", "", { "dependencies": { "bun-types": "1.2.11" } }, "sha512-ZLbbI91EmmGwlWTRWuV6J19IUiUC5YQ3TCEuSHI3usIP75kuoA8/0PVF+LTrbEnVc8JIhpElWOxv1ocI1fJBbw=="],
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
+    "@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.30.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.30.1", "@typescript-eslint/type-utils": "8.30.1", "@typescript-eslint/utils": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.31.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.31.1", "@typescript-eslint/type-utils": "8.31.1", "@typescript-eslint/utils": "8.31.1", "@typescript-eslint/visitor-keys": "8.31.1", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.30.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.30.1", "@typescript-eslint/types": "8.30.1", "@typescript-eslint/typescript-estree": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.31.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.31.1", "@typescript-eslint/types": "8.31.1", "@typescript-eslint/typescript-estree": "8.31.1", "@typescript-eslint/visitor-keys": "8.31.1", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.29.1", "", { "dependencies": { "@typescript-eslint/types": "8.29.1", "@typescript-eslint/visitor-keys": "8.29.1" } }, "sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.31.1", "", { "dependencies": { "@typescript-eslint/types": "8.31.1", "@typescript-eslint/visitor-keys": "8.31.1" } }, "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.30.1", "", { "dependencies": { "@typescript-eslint/typescript-estree": "8.30.1", "@typescript-eslint/utils": "8.30.1", "debug": "^4.3.4", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.31.1", "", { "dependencies": { "@typescript-eslint/typescript-estree": "8.31.1", "@typescript-eslint/utils": "8.31.1", "debug": "^4.3.4", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.29.1", "", {}, "sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.31.1", "", {}, "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.29.1", "", { "dependencies": { "@typescript-eslint/types": "8.29.1", "@typescript-eslint/visitor-keys": "8.29.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.31.1", "", { "dependencies": { "@typescript-eslint/types": "8.31.1", "@typescript-eslint/visitor-keys": "8.31.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.29.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.29.1", "@typescript-eslint/types": "8.29.1", "@typescript-eslint/typescript-estree": "8.29.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.31.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.31.1", "@typescript-eslint/types": "8.31.1", "@typescript-eslint/typescript-estree": "8.31.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.31.1", "", { "dependencies": { "@typescript-eslint/types": "8.31.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw=="],
 
     "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
@@ -268,7 +268,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.2.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-b5ITZMnVdf3m1gMvJHG+gIfeJHiQPJak0f7925Hxu6ZN5VKA8AGy4GZ4lM+Xkn6jtWxg5S3ldWvfmXdvnkp3GQ=="],
+    "bun-types": ["bun-types@1.2.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-dbkp5Lo8HDrXkLrONm6bk+yiiYQSntvFUzQp0v3pzTAsXk6FtgVMjdQ+lzFNVAmQFUkPQZ3WMZqH5tTo+Dp/IA=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -354,11 +354,11 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.25.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.20.0", "@eslint/config-helpers": "^0.2.1", "@eslint/core": "^0.13.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.25.0", "@eslint/plugin-kit": "^0.2.8", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.3.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-MsBdObhM4cEwkzCiraDv7A6txFXEqtNXOb877TsSp2FCkBNl8JfVQrmiuDqC1IkejT6JLPzYBXx/xAiYhyzgGA=="],
+    "eslint": ["eslint@9.25.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.20.0", "@eslint/config-helpers": "^0.2.1", "@eslint/core": "^0.13.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.25.1", "@eslint/plugin-kit": "^0.2.8", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.3.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.2", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA=="],
 
-    "eslint-plugin-perfectionist": ["eslint-plugin-perfectionist@4.11.0", "", { "dependencies": { "@typescript-eslint/types": "^8.29.0", "@typescript-eslint/utils": "^8.29.0", "natural-orderby": "^5.0.0" }, "peerDependencies": { "eslint": ">=8.45.0" } }, "sha512-5s+ehXydnLPQpLDj5mJ0CnYj2fQe6v6gKA3tS+FZVBLzwMOh8skH+l+1Gni08rG0SdEcNhJyjQp/mEkDYK8czw=="],
+    "eslint-plugin-perfectionist": ["eslint-plugin-perfectionist@4.12.3", "", { "dependencies": { "@typescript-eslint/types": "^8.31.0", "@typescript-eslint/utils": "^8.31.0", "natural-orderby": "^5.0.0" }, "peerDependencies": { "eslint": ">=8.45.0" } }, "sha512-V0dmpq6fBbn0BYofHsiRuuY9wgkKMDkdruM0mIRBIJ8XZ8vEaTAZqFsywm40RuWNVnduWBt5HO1ZZ+flE2yqjg=="],
 
     "eslint-plugin-prettier": ["eslint-plugin-prettier@5.2.6", "", { "dependencies": { "prettier-linter-helpers": "^1.0.0", "synckit": "^0.11.0" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ=="],
 
@@ -790,7 +790,7 @@
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "typescript-eslint": ["typescript-eslint@8.30.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.30.1", "@typescript-eslint/parser": "8.30.1", "@typescript-eslint/utils": "8.30.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-D7lC0kcehVH7Mb26MRQi64LMyRJsj3dToJxM1+JVTl53DQSV5/7oUGWQLcKl1C1KnoVHxMMU2FNQMffr7F3Row=="],
+    "typescript-eslint": ["typescript-eslint@8.31.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.31.1", "@typescript-eslint/parser": "8.31.1", "@typescript-eslint/utils": "8.31.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
@@ -860,27 +860,7 @@
 
     "@semantic-release/release-notes-generator/get-stream": ["get-stream@7.0.1", "", {}, "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="],
 
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1" } }, "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.30.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.30.1", "@typescript-eslint/types": "8.30.1", "@typescript-eslint/typescript-estree": "8.30.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1" } }, "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ=="],
-
-    "@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.29.1", "", { "dependencies": { "@typescript-eslint/types": "8.29.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils": ["@typescript-eslint/utils@8.30.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.30.1", "@typescript-eslint/types": "8.30.1", "@typescript-eslint/typescript-estree": "8.30.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ=="],
-
-    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.29.1", "", { "dependencies": { "@typescript-eslint/types": "8.29.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg=="],
-
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
 
     "clean-stack/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -1302,8 +1282,6 @@
 
     "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
-    "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.30.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.4.0", "@typescript-eslint/scope-manager": "8.30.1", "@typescript-eslint/types": "8.30.1", "@typescript-eslint/typescript-estree": "8.30.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ=="],
-
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
@@ -1311,22 +1289,6 @@
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@octokit/plugin-throttling/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1" } }, "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
@@ -1392,18 +1354,6 @@
 
     "signale/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1" } }, "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.30.1", "", {}, "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.30.1", "", { "dependencies": { "@typescript-eslint/types": "8.30.1", "@typescript-eslint/visitor-keys": "8.30.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
-
     "env-ci/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "npm/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -1440,14 +1390,8 @@
 
     "signale/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
-
     "pkg-conf/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
 
     "signale/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "dist/index.js",
         "dist/index.js.map",
         "dist/*.d.ts",
-        "LICENSE.MD"
+        "LICENSE.md"
     ],
     "keywords": [
         "transcription",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
     "name": "paragrafs",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "author": "Ragaeeb Haq",
     "main": "dist/index.js",
     "devDependencies": {
-        "@eslint/js": "^9.25.0",
-        "@types/bun": "^1.2.10",
-        "@types/node": "^22.14.1",
-        "eslint": "^9.25.0",
+        "@eslint/js": "^9.25.1",
+        "@types/bun": "^1.2.11",
+        "@types/node": "^22.15.3",
+        "eslint": "^9.25.1",
         "eslint-config-prettier": "^10.1.2",
-        "eslint-plugin-perfectionist": "^4.11.0",
+        "eslint-plugin-perfectionist": "^4.12.3",
         "eslint-plugin-prettier": "^5.2.6",
         "globals": "^16.0.0",
         "prettier": "^3.5.3",
         "semantic-release": "^24.2.3",
         "tsup": "^8.4.0",
-        "typescript-eslint": "^8.30.1"
+        "typescript-eslint": "^8.31.1"
     },
     "description": "A lightweight TypeScript library designed to reconstruct paragraphs from OCRed inputs and transcriptions.",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     },
     "description": "A lightweight TypeScript library designed to reconstruct paragraphs from OCRed inputs and transcriptions.",
     "engines": {
-        "bun": ">=1.2.9",
+        "bun": ">=1.2.11",
         "node": ">=23.0.0"
     },
     "files": [
         "dist/index.js",
         "dist/index.js.map",
         "dist/*.d.ts",
-        "LICENSE"
+        "LICENSE.MD"
     ],
     "keywords": [
         "transcription",

--- a/src/textUtils.ts
+++ b/src/textUtils.ts
@@ -1,3 +1,5 @@
+import type { Hints } from './types';
+
 /**
  * Checks if a text string ends with a punctuation mark (period, question mark, exclamation mark).
  * Supports both Latin and Arabic punctuation.
@@ -22,4 +24,36 @@ export const formatSecondsToTimestamp = (seconds: number): string => {
     return hrs > 0
         ? `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
         : `${mins}:${secs.toString().padStart(2, '0')}`;
+};
+
+/**
+ * Strip leading/trailing punctuation/symbols, remove Arabic diacritics, NFC-normalize.
+ */
+export const normalizeWord = (w: string) => {
+    return (
+        w
+            // decompose to strip diacritics
+            .normalize('NFD')
+            // remove Arabic diacritic marks
+            .replace(/[\u064B-\u065F]/g, '')
+            // strip any punctuation or symbol at start/end (Unicode property escapes)
+            .replace(/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu, '')
+            // recompose
+            .normalize('NFC')
+    );
+};
+
+export const createHints = (...hints: string[]) => {
+    const hintMap: Hints = {};
+    for (const hint of hints) {
+        const words = hint.split(' ');
+        const first = words[0];
+        if (!hintMap[first]) {
+            hintMap[first] = [];
+        }
+
+        hintMap[first].push(words);
+    }
+
+    return hintMap;
 };

--- a/src/textUtils.ts
+++ b/src/textUtils.ts
@@ -28,6 +28,16 @@ export const formatSecondsToTimestamp = (seconds: number): string => {
 
 /**
  * Strip leading/trailing punctuation/symbols, remove Arabic diacritics, NFC-normalize.
+ * Normalizes a word by removing diacritics and punctuation.
+ *
+ * This function:
+ * 1. Decomposes Unicode characters (NFD normalization)
+ * 2. Removes Arabic diacritics
+ * 3. Strips leading and trailing punctuation or symbols
+ * 4. Recomposes Unicode characters (NFC normalization)
+ *
+ * @param {string} w - The word to normalize
+ * @returns {string} The normalized word
  */
 export const normalizeWord = (w: string) => {
     return (
@@ -43,6 +53,15 @@ export const normalizeWord = (w: string) => {
     );
 };
 
+/**
+ * Creates a map of hints organized by their first word.
+ *
+ * Takes multiple hint strings, splits each into words, and organizes them into
+ * a map where the keys are the first words and values are arrays of word arrays.
+ *
+ * @param {...string} hints - One or more hint strings to process
+ * @returns {Hints} A map of hints organized by their first word
+ */
 export const createHints = (...hints: string[]) => {
     const hintMap: Hints = {};
     for (const hint of hints) {

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -75,6 +75,40 @@ describe('transcript', () => {
                 SEGMENT_BREAK,
             ]);
         });
+
+        it('should insert a marker and insert the hint', () => {
+            const tokens = [
+                { end: 1, start: 0, text: 'The' },
+                { end: 3, start: 2, text: 'quick' },
+                { end: 5, start: 4, text: 'brown' },
+                { end: 6.5, start: 6, text: 'fox' },
+                { end: 7, start: 6.5, text: 'Alright' },
+                { end: 9, start: 8, text: 'Jumps' },
+                { end: 10, start: 9, text: 'right' },
+                { end: 11, start: 10, text: 'over' },
+                { end: 13, start: 12, text: 'the' },
+                { end: 18, start: 17, text: 'lazy' },
+                { end: 20, start: 19, text: 'dog.' },
+            ];
+
+            const actual = markTokensWithDividers(tokens, { fillers: [], gapThreshold: 10, hints: ['Alright'] });
+
+            expect(actual).toEqual([
+                { end: 1, start: 0, text: 'The' },
+                { end: 3, start: 2, text: 'quick' },
+                { end: 5, start: 4, text: 'brown' },
+                { end: 6.5, start: 6, text: 'fox' },
+                SEGMENT_BREAK,
+                { end: 7, start: 6.5, text: 'Alright' },
+                { end: 9, start: 8, text: 'Jumps' },
+                { end: 10, start: 9, text: 'right' },
+                { end: 11, start: 10, text: 'over' },
+                { end: 13, start: 12, text: 'the' },
+                { end: 18, start: 17, text: 'lazy' },
+                { end: 20, start: 19, text: 'dog.' },
+                SEGMENT_BREAK,
+            ]);
+        });
     });
 
     describe('groupMarkedTokensIntoSegments', () => {
@@ -368,6 +402,54 @@ describe('transcript', () => {
                 .map((token) => (token as any).text);
 
             expect(tokenTexts).toEqual(['Hello', 'world']);
+        });
+
+        it('should support hints', () => {
+            const segments: Segment[] = [
+                {
+                    end: 10,
+                    start: 0,
+                    text: 'The quick brown Fox jumps right over the lazy dog',
+                    tokens: [
+                        { end: 1, start: 0, text: 'The' },
+                        { end: 2, start: 1.5, text: 'quick' },
+                        { end: 3, start: 2, text: 'Fox' },
+                        { end: 4, start: 3, text: 'jumps' },
+                        { end: 6, start: 5, text: 'right' },
+                        { end: 7, start: 6, text: 'over' },
+                        { end: 8, start: 7, text: 'the' },
+                        { end: 9, start: 8, text: 'lazy' },
+                        { end: 10, start: 9, text: 'dog' },
+                    ],
+                },
+            ];
+
+            const result = markAndCombineSegments(segments, {
+                fillers: [],
+                gapThreshold: 10,
+                hints: ['Fox'],
+                maxSecondsPerSegment: 100,
+                minWordsPerSegment: 1,
+            });
+
+            expect(result).toEqual([
+                {
+                    end: 10,
+                    start: 0,
+                    tokens: [
+                        { end: 1, start: 0, text: 'The' },
+                        { end: 2, start: 1.5, text: 'quick' },
+                        SEGMENT_BREAK,
+                        { end: 3, start: 2, text: 'Fox' },
+                        { end: 4, start: 3, text: 'jumps' },
+                        { end: 6, start: 5, text: 'right' },
+                        { end: 7, start: 6, text: 'over' },
+                        { end: 8, start: 7, text: 'the' },
+                        { end: 9, start: 8, text: 'lazy' },
+                        { end: 10, start: 9, text: 'dog' },
+                    ],
+                },
+            ]);
         });
 
         it('should handle time gaps between tokens', () => {

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -870,7 +870,7 @@ describe('transcript', () => {
             });
         });
 
-        it('should skip single-word gaps and interpolate multi-word gaps correctly', () => {
+        it('should interpolate multi-word gaps correctly', () => {
             const segment: Segment = {
                 end: 10,
                 start: 0,
@@ -881,24 +881,64 @@ describe('transcript', () => {
                     { end: 4, start: 3, text: 'brown' },
                     { end: 5.5, start: 5, text: 'jumps' },
                     { end: 6, start: 5.5, text: 'right' },
-                    { end: 8, start: 9, text: 'lazy' },
+                    { end: 9, start: 8, text: 'lazy' },
                     { end: 10, start: 9, text: 'dog' },
                 ],
             };
             const actual = mapTokensToGroundTruth(segment);
-            // round times for stable comparisons
-            const got = roundTokenTimes(actual.tokens as Token[]);
+            const got = roundTokenTimes(actual.tokens);
+
             expect(got).toEqual([
-                { end: 1.0, start: 0.0, text: 'The' },
-                { end: 3.0, start: 2.0, text: 'quick' },
-                { end: 4.0, start: 3.0, text: 'brown' },
-                { end: 5.5, start: 5.0, text: 'jumps' },
-                { end: 6.0, start: 5.5, text: 'right' },
-                // two-word gap [over,the] from 6 to 9 => interval=3, step=1 => over@7, the@8
-                { end: 8.0, start: 7.0, text: 'over' },
-                { end: 9.0, start: 8.0, text: 'the' },
-                { end: 8.0, start: 9.0, text: 'lazy' },
-                { end: 10.0, start: 9.0, text: 'dog.' },
+                {
+                    end: 1,
+                    start: 0,
+                    text: 'The',
+                },
+                {
+                    end: 3,
+                    start: 2,
+                    text: 'quick',
+                },
+                {
+                    end: 4,
+                    start: 3,
+                    text: 'brown',
+                },
+                {
+                    end: 5,
+                    start: 4.5,
+                    text: 'fox',
+                },
+                {
+                    end: 5.5,
+                    start: 5,
+                    text: 'jumps',
+                },
+                {
+                    end: 6,
+                    start: 5.5,
+                    text: 'right',
+                },
+                {
+                    end: 7.33,
+                    start: 6.67,
+                    text: 'over',
+                },
+                {
+                    end: 8,
+                    start: 7.33,
+                    text: 'the',
+                },
+                {
+                    end: 9,
+                    start: 8,
+                    text: 'lazy',
+                },
+                {
+                    end: 10,
+                    start: 9,
+                    text: 'dog.',
+                },
             ]);
         });
 

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -41,7 +41,7 @@ export const estimateSegmentFromToken = ({ end, start, text }: Token): Segment =
  * @param {Object} options - Configuration options
  * @param {string[]} [options.fillers] - Optional array of filler words to mark as segment breaks
  * @param {number} options.gapThreshold - Minimum time gap (in seconds) to consider a segment break
- * @param {string[]} [options.hints] - Optional array of multi-word phrases that trigger a break when fully matched
+ * @param {Hints} [options.hints] - Hints created with the createHints() function to indicate when to insert a new segment break.
  * @returns {MarkedToken[]} Tokens with segment break markers inserted
  */
 export const markTokensWithDividers = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,38 @@
+export type Hints = Record<string, string[][]>;
+
+/**
+ * Represents a segment during the marking and processing stage.
+ * Contains an array of tokens that may include segment break markers.
+ */
+export type MarkedSegment = {
+    /**
+     * End time of the segment in seconds
+     */
+    end: number;
+
+    /**
+     * Start time of the segment in seconds
+     */
+    start: number;
+
+    /**
+     * Array of tokens and segment break markers that make up this segment
+     */
+    tokens: MarkedToken[];
+};
+
+/**
+ * Represents either a token or a segment break marker.
+ * Used during the processing of text to identify natural break points.
+ */
+export type MarkedToken = 'SEGMENT_BREAK' | Token;
+
+export type MarkTokensWithDividersOptions = {
+    fillers?: string[];
+    gapThreshold: number;
+    hints?: Hints;
+};
+
 /**
  * Represents a segment of text with timing information and optional word-level tokens.
  * A segment is a higher-level structure that contains a sequence of related tokens.
@@ -28,35 +63,3 @@ export type Token = {
      */
     text: string;
 };
-
-/**
- * Constant used to mark segment breaks during processing.
- */
-export const SEGMENT_BREAK = 'SEGMENT_BREAK';
-
-/**
- * Represents a segment during the marking and processing stage.
- * Contains an array of tokens that may include segment break markers.
- */
-export type MarkedSegment = {
-    /**
-     * End time of the segment in seconds
-     */
-    end: number;
-
-    /**
-     * Start time of the segment in seconds
-     */
-    start: number;
-
-    /**
-     * Array of tokens and segment break markers that make up this segment
-     */
-    tokens: MarkedToken[];
-};
-
-/**
- * Represents either a token or a segment break marker.
- * Used during the processing of text to identify natural break points.
- */
-export type MarkedToken = 'SEGMENT_BREAK' | Token;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { SEGMENT_BREAK } from './utils/constants';
+
 export type Hints = Record<string, string[][]>;
 
 /**
@@ -25,7 +27,7 @@ export type MarkedSegment = {
  * Represents either a token or a segment break marker.
  * Used during the processing of text to identify natural break points.
  */
-export type MarkedToken = 'SEGMENT_BREAK' | Token;
+export type MarkedToken = Token | typeof SEGMENT_BREAK;
 
 export type MarkTokensWithDividersOptions = {
     fillers?: string[];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Constant used to mark segment breaks during processing.
+ */
+export const SEGMENT_BREAK = 'SEGMENT_BREAK';

--- a/src/utils/lcs.ts
+++ b/src/utils/lcs.ts
@@ -1,0 +1,59 @@
+type LCSTable = number[][];
+
+/**
+ * Builds a dynamic programming table for Longest Common Subsequence (LCS).
+ *
+ * @param a - Normalized list of original token strings
+ * @param b - Normalized list of ground truth words
+ * @returns 2D array representing the LCS table (dimensions: (a.length + 1) x (b.length + 1))
+ *
+ * @complexity O(m * n) where m and n are lengths of `a` and `b`
+ */
+export const buildLcsTable = (a: string[], b: string[]) => {
+    const m = a.length;
+    const n = b.length;
+    const table: LCSTable = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+    for (let i = 0; i < m; i++) {
+        for (let j = 0; j < n; j++) {
+            if (a[i] === b[j]) {
+                table[i + 1][j + 1] = table[i][j] + 1;
+            } else {
+                table[i + 1][j + 1] = Math.max(table[i][j + 1], table[i + 1][j]);
+            }
+        }
+    }
+
+    return table;
+};
+
+/**
+ * Extracts index pairs of matched words from the LCS table.
+ *
+ * Backtracks through the LCS table to find all aligned index pairs
+ * between the original and ground truth arrays.
+ *
+ * @param table - LCS dynamic programming table
+ * @param original - Normalized original token texts
+ * @param ground - Normalized ground truth words
+ * @returns Array of match objects with `gtIndex` and `origIndex` pairs
+ */
+export function extractLcsMatches(table: LCSTable, original: string[], ground: string[]) {
+    const matches: { gtIndex: number; origIndex: number }[] = [];
+    let i = original.length;
+    let j = ground.length;
+
+    while (i > 0 && j > 0) {
+        if (original[i - 1] === ground[j - 1]) {
+            matches.push({ gtIndex: j - 1, origIndex: i - 1 });
+            i--;
+            j--;
+        } else if (table[i - 1][j] >= table[i][j - 1]) {
+            i--;
+        } else {
+            j--;
+        }
+    }
+
+    return matches.reverse();
+}

--- a/src/utils/transcriptUtils.ts
+++ b/src/utils/transcriptUtils.ts
@@ -1,0 +1,57 @@
+import type { Hints, Token } from '@/types';
+
+export const isHintMatched = (tokens: Token[], hints: Hints, index: number) => {
+    const token = tokens[index];
+    const candidates = hints[token.text];
+
+    if (candidates) {
+        for (const words of candidates) {
+            const len = words.length;
+
+            if (index + len <= tokens.length) {
+                let match = true;
+
+                for (let k = 0; k < len; k++) {
+                    if (tokens[index + k].text !== words[k]) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+};
+
+/**
+ * Generates interpolated tokens with evenly spaced timestamps for missing words.
+ *
+ * The function assumes a gap between two tokens and fills it with estimated tokens
+ * for the ground truth words that were not matched. The time range is divided evenly
+ * among the words.
+ *
+ * @param startTime - Start time of the gap
+ * @param endTime - End time of the gap
+ * @param words - List of ground truth words to interpolate into this range
+ * @returns Array of synthetic `Token` objects with estimated timings
+ */
+export const interpolateMissingWords = (startTime: number, endTime: number, words: string[]): Token[] => {
+    const wordCount = words.length;
+    if (wordCount <= 1) {
+        return [];
+    }
+
+    const interval = (endTime - startTime) / (wordCount + 1);
+    return words.map((word, index) => {
+        const start = startTime + interval * (index + 1);
+        return {
+            end: start + interval,
+            start,
+            text: word,
+        };
+    });
+};

--- a/src/utils/transcriptUtils.ts
+++ b/src/utils/transcriptUtils.ts
@@ -41,13 +41,16 @@ export const isHintMatched = (tokens: Token[], hints: Hints, index: number) => {
  */
 export const interpolateMissingWords = (startTime: number, endTime: number, words: string[]): Token[] => {
     const wordCount = words.length;
-    if (wordCount <= 1) {
+    if (wordCount === 0 || endTime <= startTime) {
         return [];
     }
 
-    const interval = (endTime - startTime) / (wordCount + 1);
+    // place a single word in the middle of the interval
+    const interval = wordCount === 1 ? (endTime - startTime) / 2 : (endTime - startTime) / (wordCount + 1);
+    const positions = wordCount === 1 ? [interval] : Array.from({ length: wordCount }, (_, i) => interval * (i + 1));
+
     return words.map((word, index) => {
-        const start = startTime + interval * (index + 1);
+        const start = startTime + positions[index];
         return {
             end: start + interval,
             start,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for aligning AI-generated word timestamps to human-edited transcript text using a ground-truth token mapping feature.
  - Introduced multi-word hint support for segment marking, enabling segment breaks based on matching phrases.
  - Added new utility functions for word normalization and hint creation.
  - Introduced longest common subsequence (LCS) algorithm utilities for transcript alignment.

- **Bug Fixes**
  - Improved punctuation handling and timing interpolation when aligning tokens to ground truth.

- **Documentation**
  - Updated README with new version badge, Bun installation instructions, feature descriptions, usage examples, and detailed API reference.

- **Tests**
  - Expanded test coverage for hint-based segment marking and ground-truth token mapping.

- **Chores**
  - Upgraded dependencies and updated minimum required Bun version.
  - Improved type definitions and code organization for clarity and maintainability.
  - Added new constants and reorganized type declarations for segment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->