### PR TITLE
feat(hints): Hints always produce a new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub License](https://img.shields.io/github/license/ragaeeb/paragrafs)
 ![GitHub Release](https://img.shields.io/github/v/release/ragaeeb/paragrafs)
 [![codecov](https://codecov.io/gh/ragaeeb/paragrafs/graph/badge.svg?token=B3IRBVOS3H)](https://codecov.io/gh/ragaeeb/paragrafs)
-[![Size](https://deno.bundlejs.com/badge?q=paragrafs@1.2.0&badge=detailed)](https://bundlejs.com/?q=paragrafs%401.2.0)
+[![Size](https://deno.bundlejs.com/badge?q=paragrafs@latest&badge=detailed)](https://bundlejs.com/?q=paragrafs%40latest)
 ![typescript](https://badgen.net/badge/icon/typescript?icon=typescript&label&color=blue)
 ![npm](https://img.shields.io/npm/dm/paragrafs)
 ![GitHub issues](https://img.shields.io/github/issues/ragaeeb/paragrafs)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "paragrafs",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "author": "Ragaeeb Haq",
     "main": "dist/index.js",
     "devDependencies": {
@@ -20,7 +20,7 @@
     "description": "A lightweight TypeScript library designed to reconstruct paragraphs from OCRed inputs and transcriptions.",
     "engines": {
         "bun": ">=1.2.11",
-        "node": ">=23.0.0"
+        "node": ">=22.0.0"
     },
     "files": [
         "dist/index.js",

--- a/src/transcript.test.ts
+++ b/src/transcript.test.ts
@@ -4,6 +4,7 @@ import type { MarkedSegment, MarkedToken, Segment, Token } from './types';
 
 import { createHints } from './textUtils';
 import {
+    cleanupIsolatedTokens,
     estimateSegmentFromToken,
     formatSegmentsToTimestampedTranscript,
     groupMarkedTokensIntoSegments,
@@ -539,7 +540,7 @@ describe('transcript', () => {
             minWordsPerSegment: 3,
         };
 
-        it('should process segments with fillers correctly', () => {
+        it('should process segments with fillers but collapse to prevent isolated tokens', () => {
             const segments: Segment[] = [
                 {
                     end: 2,
@@ -554,16 +555,66 @@ describe('transcript', () => {
             ];
 
             const result = markAndCombineSegments(segments, options);
+            expect(result).toEqual([
+                {
+                    end: 2,
+                    start: 0,
+                    tokens: [
+                        {
+                            end: 0.5,
+                            start: 0,
+                            text: 'Hello',
+                        },
+                        {
+                            end: 2,
+                            start: 1,
+                            text: 'world',
+                        },
+                    ],
+                },
+            ]);
+        });
 
-            expect(result).toHaveLength(1);
-            expect(result[0].tokens).toContain(SEGMENT_BREAK);
+        it('should process segments with fillers correctly', () => {
+            const segments: Segment[] = [
+                {
+                    end: 2,
+                    start: 0,
+                    text: 'Hello uh world today',
+                    tokens: [
+                        { end: 0.5, start: 0, text: 'Hello' },
+                        { end: 1, start: 0.5, text: 'uh' },
+                        { end: 2, start: 1, text: 'world' },
+                        { end: 3, start: 2, text: 'today' },
+                    ],
+                },
+            ];
 
-            // Verify filler word was replaced with segment break
-            const tokenTexts = result[0].tokens
-                .filter((token) => token !== SEGMENT_BREAK)
-                .map((token) => (token as any).text);
-
-            expect(tokenTexts).toEqual(['Hello', 'world']);
+            const result = markAndCombineSegments(segments, options);
+            expect(result).toEqual([
+                {
+                    end: 3,
+                    start: 0,
+                    tokens: [
+                        {
+                            end: 0.5,
+                            start: 0,
+                            text: 'Hello',
+                        },
+                        SEGMENT_BREAK,
+                        {
+                            end: 2,
+                            start: 1,
+                            text: 'world',
+                        },
+                        {
+                            end: 3,
+                            start: 2,
+                            text: 'today',
+                        },
+                    ],
+                },
+            ]);
         });
 
         it('should support hints', () => {
@@ -765,33 +816,56 @@ describe('transcript', () => {
             ];
 
             const result = markAndCombineSegments(segments, options);
-
-            // Expected behaviors:
-            // 1. Segment break after "world." due to punctuation
-            // 2. Segment break around "umm" due to filler
-            // 3. Segment break after "you?" due to punctuation
-            // 4. Segment break before second segment due to gap
-
-            // Count all segment breaks
-            const totalBreaks = result.reduce(
-                (count, segment) => count + segment.tokens.filter((token) => token === SEGMENT_BREAK).length,
-                0,
-            );
-
-            // We should have multiple breaks in this complex scenario
-            expect(totalBreaks).toBeGreaterThan(3);
-
-            // Verify that both segments were processed correctly
-            const allNonBreakTokens = result.flatMap(
-                (segment) => segment.tokens.filter((token) => token !== SEGMENT_BREAK) as any[],
-            );
-
-            const allTexts = allNonBreakTokens.map((token) => token.text);
-
-            expect(allTexts).toContain('Hello');
-            expect(allTexts).toContain('fine');
-            // Filler should be removed
-            expect(allTexts).not.toContain('umm');
+            expect(result).toEqual([
+                {
+                    end: 9,
+                    start: 0,
+                    tokens: [
+                        {
+                            end: 1,
+                            start: 0,
+                            text: 'Hello',
+                        },
+                        {
+                            end: 2,
+                            start: 1,
+                            text: 'world.',
+                        },
+                        SEGMENT_BREAK,
+                        {
+                            end: 4,
+                            start: 3,
+                            text: 'How',
+                        },
+                        {
+                            end: 4.5,
+                            start: 4,
+                            text: 'are',
+                        },
+                        {
+                            end: 5,
+                            start: 4.5,
+                            text: 'you?',
+                        },
+                        SEGMENT_BREAK,
+                        {
+                            end: 8.3,
+                            start: 8,
+                            text: 'I',
+                        },
+                        {
+                            end: 8.6,
+                            start: 8.3,
+                            text: 'am',
+                        },
+                        {
+                            end: 9,
+                            start: 8.6,
+                            text: 'fine',
+                        },
+                    ],
+                },
+            ]);
         });
 
         it('should handle empty input gracefully', () => {
@@ -1147,6 +1221,141 @@ describe('transcript', () => {
             const estimated = estimateSegmentFromToken(segment);
             const actual = mapTokensToGroundTruth(segment);
             expect(actual).toEqual(estimated);
+        });
+    });
+
+    describe('cleanupIsolatedTokens', () => {
+        it('should clean up the isolated token since it will be followed by a break', () => {
+            const actual = cleanupIsolatedTokens([
+                {
+                    end: 1,
+                    start: 0,
+                    text: 'The',
+                },
+                {
+                    end: 3,
+                    start: 2,
+                    text: 'quick',
+                },
+                {
+                    end: 5,
+                    start: 4,
+                    text: 'brown',
+                },
+                {
+                    end: 7,
+                    start: 6,
+                    text: 'fox',
+                },
+                {
+                    end: 9,
+                    start: 8,
+                    text: 'jumps',
+                },
+                {
+                    end: 11,
+                    start: 10,
+                    text: 'right',
+                },
+                {
+                    end: 13,
+                    start: 12,
+                    text: 'over',
+                },
+                {
+                    end: 15,
+                    start: 14,
+                    text: 'the',
+                },
+                {
+                    end: 17,
+                    start: 16,
+                    text: 'lazy',
+                },
+                {
+                    end: 19,
+                    start: 18,
+                    text: 'dog.',
+                },
+                SEGMENT_BREAK,
+                {
+                    end: 20,
+                    start: 19,
+                    text: 'Okay.',
+                },
+                SEGMENT_BREAK,
+                ALWAYS_BREAK,
+                SEGMENT_BREAK,
+                {
+                    end: 25,
+                    start: 24,
+                    text: 'Alright',
+                },
+            ]);
+
+            expect(actual).toEqual([
+                {
+                    end: 1,
+                    start: 0,
+                    text: 'The',
+                },
+                {
+                    end: 3,
+                    start: 2,
+                    text: 'quick',
+                },
+                {
+                    end: 5,
+                    start: 4,
+                    text: 'brown',
+                },
+                {
+                    end: 7,
+                    start: 6,
+                    text: 'fox',
+                },
+                {
+                    end: 9,
+                    start: 8,
+                    text: 'jumps',
+                },
+                {
+                    end: 11,
+                    start: 10,
+                    text: 'right',
+                },
+                {
+                    end: 13,
+                    start: 12,
+                    text: 'over',
+                },
+                {
+                    end: 15,
+                    start: 14,
+                    text: 'the',
+                },
+                {
+                    end: 17,
+                    start: 16,
+                    text: 'lazy',
+                },
+                {
+                    end: 19,
+                    start: 18,
+                    text: 'dog.',
+                },
+                {
+                    end: 20,
+                    start: 19,
+                    text: 'Okay.',
+                },
+                ALWAYS_BREAK,
+                {
+                    end: 25,
+                    start: 24,
+                    text: 'Alright',
+                },
+            ]);
         });
     });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { SEGMENT_BREAK } from './utils/constants';
+import { ALWAYS_BREAK, SEGMENT_BREAK } from './utils/constants';
 
 export type Hints = Record<string, string[][]>;
 
@@ -27,7 +27,7 @@ export type MarkedSegment = {
  * Represents either a token or a segment break marker.
  * Used during the processing of text to identify natural break points.
  */
-export type MarkedToken = Token | typeof SEGMENT_BREAK;
+export type MarkedToken = Token | typeof ALWAYS_BREAK | typeof SEGMENT_BREAK;
 
 export type MarkTokensWithDividersOptions = {
     fillers?: string[];

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,3 +2,8 @@
  * Constant used to mark segment breaks during processing.
  */
 export const SEGMENT_BREAK = 'SEGMENT_BREAK';
+
+/**
+ * Constant used to mark that we should always start a break when encountering this.
+ */
+export const ALWAYS_BREAK = 'ALWAYS_BREAK';


### PR DESCRIPTION
And clean up line breaks so we don't isolate tokens by itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved transcript segmentation with a new break type that ensures certain breaks always start a new segment.
  - Enhanced handling and cleanup of isolated tokens and fillers in transcript formatting.

- **Bug Fixes**
  - Prevented creation of isolated single-token lines and duplicate segment breaks in transcripts.

- **Tests**
  - Expanded and refined test coverage for break token handling, filler processing, and segment formatting.

- **Documentation**
  - Updated README badge URLs for package size to always reflect the latest version.

- **Chores**
  - Lowered minimum required Node.js version and incremented package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->